### PR TITLE
feat: use js to disable the form

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,12 +6,20 @@ import { LiveSocket } from "phoenix_live_view";
 import topbar from "../vendor/topbar";
 // Include Tippy.js for tooltips
 import tippy, { animateFill, roundArrow } from "tippy.js";
+// Import hooks
+import { FormHook } from "./hooks/form";
+
+// Define hooks
+const Hooks = {
+  FormHook,
+};
 
 const csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content");
 const liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },
+  hooks: Hooks,
 });
 
 // Show progress bar on live navigation and form submits

--- a/assets/js/hooks/form.js
+++ b/assets/js/hooks/form.js
@@ -1,0 +1,30 @@
+export const FormHook = {
+  mounted() {
+    const required = this.el.dataset.required.split(",");
+    const button = this.el.querySelector("button[type=submit]");
+
+    // If any of the required fields are empty, disable the submit button
+    // else enable it.
+    const checkRequired = () => {
+      const empty = required.some((field) => {
+        const input = this.el.querySelector(`[name=${field}]`);
+        return !input.value;
+      });
+
+      if (empty) {
+        button.setAttribute("disabled", true);
+      } else {
+        button.removeAttribute("disabled");
+      }
+    };
+
+    // Check required fields on page load
+    checkRequired();
+
+    // Check required fields on input change
+    for (const field of required) {
+      const input = this.el.querySelector(`[name=${field}]`);
+      input.addEventListener("input", checkRequired);
+    }
+  },
+};

--- a/lib/tenantee_web/live/property_live/add.ex
+++ b/lib/tenantee_web/live/property_live/add.ex
@@ -24,7 +24,7 @@ defmodule TenanteeWeb.PropertyLive.Add do
              name: name,
              description: description,
              address: address,
-             price: Money.new(price, currency)
+             price: Helper.handle_price(price, currency)
            }) do
       {:noreply, handle_success(socket, property.id, name)}
     else

--- a/lib/tenantee_web/live/property_live/add.ex
+++ b/lib/tenantee_web/live/property_live/add.ex
@@ -36,14 +36,21 @@ defmodule TenanteeWeb.PropertyLive.Add do
   def render(assigns) do
     assigns = assign(assigns, :disabled, Helper.is_submit_disabled?(assigns))
 
+    # TODO: Allow FormHook to handle min, max for number inputs
+
     ~H"""
     <a class="text-gray-500" href={~p"/properties"}>
       <.icon name="hero-arrow-left" /> Back to properties
     </a>
     <h1 class="text-3xl font-bold my-4">Create new property</h1>
-    <form phx-submit="create" class="flex flex-col gap-4 max-w-xs">
+    <form
+      id="property-add-form"
+      phx-hook="FormHook"
+      phx-submit="create"
+      class="flex flex-col gap-4 max-w-xs"
+      data-required="name,address,price"
+    >
       <.input
-        phx-change="change"
         type="text"
         name="name"
         value={@name}
@@ -52,7 +59,6 @@ defmodule TenanteeWeb.PropertyLive.Add do
         required
       />
       <.input
-        phx-change="change"
         type="text"
         name="address"
         value={@address}
@@ -61,7 +67,6 @@ defmodule TenanteeWeb.PropertyLive.Add do
         required
       />
       <.input
-        phx-change="change"
         type="number"
         name="price"
         min="0"
@@ -72,7 +77,6 @@ defmodule TenanteeWeb.PropertyLive.Add do
         required
       />
       <.input
-        phx-change="change"
         type="textarea"
         name="description"
         value={@description}

--- a/lib/tenantee_web/live/property_live/edit.ex
+++ b/lib/tenantee_web/live/property_live/edit.ex
@@ -20,8 +20,9 @@ defmodule TenanteeWeb.PropertyLive.Edit do
              description: description,
              address: address,
              price: Money.new(price, currency)
-           }) do
-      {:noreply, handle_success(socket, name)}
+           }),
+         {:ok, property} <- Property.get(socket.assigns.id) do
+      {:noreply, handle_success(socket, name, property)}
     else
       {:error, reason} ->
         {:noreply, Helper.handle_errors(socket, reason)}
@@ -86,7 +87,12 @@ defmodule TenanteeWeb.PropertyLive.Edit do
     """
   end
 
-  def handle_success(socket, name) do
-    put_flash(socket, :info, "#{name} was updated successfully.")
+  def handle_success(socket, name, property) do
+    socket
+    |> assign(:name, property.name)
+    |> assign(:address, property.address)
+    |> assign(:price, property.price.amount |> to_string())
+    |> assign(:description, property.description)
+    |> put_flash(:info, "#{name} was updated successfully.")
   end
 end

--- a/lib/tenantee_web/live/property_live/edit.ex
+++ b/lib/tenantee_web/live/property_live/edit.ex
@@ -19,7 +19,7 @@ defmodule TenanteeWeb.PropertyLive.Edit do
              name: name,
              description: description,
              address: address,
-             price: Money.new(price, currency)
+             price: Helper.handle_price(price, currency)
            }),
          {:ok, property} <- Property.get(socket.assigns.id) do
       {:noreply, handle_success(socket, name, property)}
@@ -40,7 +40,7 @@ defmodule TenanteeWeb.PropertyLive.Edit do
     </a>
     <h1 class="text-3xl font-bold my-4">Edit <%= @name %></h1>
     <form
-      id="edit-property-form"
+      id="property-edit-form"
       phx-hook="FormHook"
       phx-submit="update"
       class="flex flex-col gap-4 max-w-xs"

--- a/lib/tenantee_web/live/property_live/edit.ex
+++ b/lib/tenantee_web/live/property_live/edit.ex
@@ -8,11 +8,6 @@ defmodule TenanteeWeb.PropertyLive.Edit do
     {:ok, Helper.default(socket, params)}
   end
 
-  def handle_event("change", %{"_target" => [target]} = params, socket) do
-    value = params[target]
-    {:noreply, assign(socket, String.to_existing_atom(target), value)}
-  end
-
   def handle_event(
         "update",
         %{"name" => name, "description" => description, "address" => address, "price" => price},
@@ -36,14 +31,21 @@ defmodule TenanteeWeb.PropertyLive.Edit do
   def render(assigns) do
     assigns = assign(assigns, :disabled, Helper.is_submit_disabled?(assigns))
 
+    # TODO: Allow FormHook to handle min, max for number inputs
+
     ~H"""
     <a class="text-gray-500" href={~p"/properties"}>
       <.icon name="hero-arrow-left" /> Back to properties
     </a>
     <h1 class="text-3xl font-bold my-4">Edit <%= @name %></h1>
-    <form phx-submit="update" class="flex flex-col gap-4 max-w-xs">
+    <form
+      id="edit-property-form"
+      phx-hook="FormHook"
+      phx-submit="update"
+      class="flex flex-col gap-4 max-w-xs"
+      data-required="name,address,price"
+    >
       <.input
-        phx-change="change"
         type="text"
         name="name"
         value={@name}
@@ -52,7 +54,6 @@ defmodule TenanteeWeb.PropertyLive.Edit do
         required
       />
       <.input
-        phx-change="change"
         type="text"
         name="address"
         value={@address}
@@ -61,7 +62,6 @@ defmodule TenanteeWeb.PropertyLive.Edit do
         required
       />
       <.input
-        phx-change="change"
         type="number"
         name="price"
         min="0"
@@ -72,7 +72,6 @@ defmodule TenanteeWeb.PropertyLive.Edit do
         required
       />
       <.input
-        phx-change="change"
         type="textarea"
         name="description"
         value={@description}

--- a/lib/tenantee_web/live/property_live/helper.ex
+++ b/lib/tenantee_web/live/property_live/helper.ex
@@ -70,4 +70,18 @@ defmodule TenanteeWeb.PropertyLive.Helper do
         put_flash(socket, :error, "Something went wrong, please try again.")
     end
   end
+
+  @doc """
+  Handles the price that we pass to the socket
+  """
+  @spec handle_price(String.t() | float(), String.t() | atom()) :: Money.t()
+  def handle_price(price, currency) when is_bitstring(price) do
+    Decimal.new(price)
+    |> Decimal.to_float()
+    |> handle_price(currency)
+  end
+
+  def handle_price(price, currency) when is_float(price) do
+    Money.from_float(price, currency)
+  end
 end

--- a/lib/tenantee_web/live/tenant_live/add.ex
+++ b/lib/tenantee_web/live/tenant_live/add.ex
@@ -7,11 +7,6 @@ defmodule TenanteeWeb.TenantLive.Add do
     {:ok, Helper.default(socket)}
   end
 
-  def handle_event("change", %{"_target" => [target]} = params, socket) do
-    value = params[target]
-    {:noreply, assign(socket, String.to_existing_atom(target), value) |> assign(:created, false)}
-  end
-
   def handle_event(
         "create",
         %{"first_name" => first_name, "last_name" => last_name},
@@ -25,7 +20,7 @@ defmodule TenanteeWeb.TenantLive.Add do
         {:noreply, handle_success(socket, tenant.id, first_name <> " " <> last_name)}
 
       {:error, _reason} ->
-        {:noreply, put_flash(socket, :error, "Something went wrong. Please try again.")}
+        {:noreply, handle_error(socket, first_name, last_name)}
     end
   end
 
@@ -37,9 +32,14 @@ defmodule TenanteeWeb.TenantLive.Add do
       <.icon name="hero-arrow-left" /> Back to tenants
     </a>
     <h1 class="text-3xl font-bold my-4">Create new tenant</h1>
-    <form phx-submit="create" class="flex flex-col gap-4 max-w-xs">
+    <form
+      id="tenant-add-form"
+      phx-hook="FormHook"
+      phx-submit="create"
+      class="flex flex-col gap-4 max-w-xs"
+      data-required="first_name,last_name"
+    >
       <.input
-        phx-change="change"
         type="text"
         name="first_name"
         value={@first_name}
@@ -48,7 +48,6 @@ defmodule TenanteeWeb.TenantLive.Add do
         required
       />
       <.input
-        phx-change="change"
         type="text"
         name="last_name"
         value={@last_name}
@@ -67,5 +66,12 @@ defmodule TenanteeWeb.TenantLive.Add do
   def handle_success(socket, id, name) do
     put_flash(socket, :info, "#{name} was created successfully.")
     |> push_navigate(to: ~p"/tenants/#{id}")
+  end
+
+  def handle_error(socket, first_name, last_name) do
+    socket
+    |> assign(:first_name, first_name)
+    |> assign(:last_name, last_name)
+    |> put_flash(:error, "Something went wrong. Please try again.")
   end
 end

--- a/lib/tenantee_web/live/tenant_live/edit.ex
+++ b/lib/tenantee_web/live/tenant_live/edit.ex
@@ -7,11 +7,6 @@ defmodule TenanteeWeb.TenantLive.Edit do
     {:ok, Helper.default(socket, params)}
   end
 
-  def handle_event("change", %{"_target" => [target]} = params, socket) do
-    value = params[target]
-    {:noreply, assign(socket, String.to_existing_atom(target), value)}
-  end
-
   def handle_event(
         "update",
         %{"first_name" => first_name, "last_name" => last_name},
@@ -22,7 +17,7 @@ defmodule TenanteeWeb.TenantLive.Edit do
            last_name: last_name
          }) do
       :ok ->
-        {:noreply, handle_success(socket, first_name <> " " <> last_name)}
+        {:noreply, handle_success(socket, first_name, last_name)}
 
       {:error, _reason} ->
         {:noreply, put_flash(socket, :error, "Something went wrong. Please try again.")}
@@ -37,9 +32,14 @@ defmodule TenanteeWeb.TenantLive.Edit do
       <.icon name="hero-arrow-left" /> Back to tenants
     </a>
     <h1 class="text-3xl font-bold my-4">Edit <%= @first_name %> <%= @last_name %></h1>
-    <form phx-submit="update" class="flex flex-col gap-4 max-w-xs">
+    <form
+      id="tenant-edit-form"
+      phx-hook="FormHook"
+      phx-submit="update"
+      class="flex flex-col gap-4 max-w-xs"
+      data-required="first_name,last_name"
+    >
       <.input
-        phx-change="change"
         type="text"
         name="first_name"
         value={@first_name}
@@ -48,7 +48,6 @@ defmodule TenanteeWeb.TenantLive.Edit do
         required
       />
       <.input
-        phx-change="change"
         type="text"
         name="last_name"
         value={@last_name}
@@ -64,7 +63,12 @@ defmodule TenanteeWeb.TenantLive.Edit do
     """
   end
 
-  def handle_success(socket, name) do
-    put_flash(socket, :info, "#{name} was created successfully.")
+  def handle_success(socket, first_name, last_name) do
+    name = "#{first_name} #{last_name}"
+
+    socket
+    |> assign(:first_name, first_name)
+    |> assign(:last_name, last_name)
+    |> put_flash(:info, "#{name} was updated successfully.")
   end
 end

--- a/test/live/config_test.exs
+++ b/test/live/config_test.exs
@@ -21,22 +21,6 @@ defmodule TenanteeWeb.ConfigLiveTest do
            |> render_submit() =~ "Configuration saved successfully!"
   end
 
-  test "enables the save button after inputting a name", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/settings")
-
-    assert view
-           |> element("[name='name']")
-           |> render_change(%{"_target" => "name", "name" => "Test Name"}) =~ "Test Name"
-
-    assert view
-           |> element("[name='name']")
-           |> render_change(%{"_target" => "name", "name" => "Test Name"})
-           |> Floki.parse_fragment!()
-           |> Floki.find("button")
-           |> List.first()
-           |> Floki.attribute("disabled") == []
-  end
-
   test "disables the currency select when we have a tenant or property", %{conn: conn} do
     generate_tenant()
     {:ok, view, _html} = live(conn, "/settings")

--- a/test/live/property/add_test.exs
+++ b/test/live/property/add_test.exs
@@ -1,0 +1,31 @@
+defmodule TenanteeWeb.PropertyAddLiveTest do
+  use TenanteeWeb.ConnCase
+  import Phoenix.LiveViewTest
+  @endpoint TenanteeWeb.Endpoint
+
+  test "renders", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/properties/new")
+
+    assert html =~ "Create new property"
+    assert html =~ "Name"
+    assert html =~ "Address"
+    assert html =~ "Price"
+    assert html =~ "Description"
+  end
+
+  test "redirects to edit page after creation", %{conn: conn} do
+    name = Faker.Company.En.name()
+    address = Faker.Address.street_address()
+    price = Faker.Commerce.price()
+
+    {:ok, og_view, _html} = live(conn, "/properties/new")
+
+    {:ok, _view, html} =
+      og_view
+      |> form("#property-add-form", %{name: name, address: address, price: price})
+      |> render_submit()
+      |> follow_redirect(conn)
+
+    assert html =~ "Edit #{name}"
+  end
+end

--- a/test/live/property/edit_test.exs
+++ b/test/live/property/edit_test.exs
@@ -1,0 +1,36 @@
+defmodule TenanteeWeb.PropertyEditLiveTest do
+  use TenanteeWeb.ConnCase
+  import Phoenix.LiveViewTest
+  import Tenantee.Test.Factory.Property
+  @endpoint TenanteeWeb.Endpoint
+
+  test "renders", %{conn: conn} do
+    {:ok, property} = generate_property()
+    {:ok, _view, html} = live(conn, "/properties/#{property.id}")
+
+    assert html =~ "Edit #{property.name}"
+
+    assert html =~ "Name"
+    assert html =~ "Address"
+    assert html =~ "Price"
+    assert html =~ "Description"
+  end
+
+  test "updates successfully", %{conn: conn} do
+    name = Faker.Company.En.name()
+    address = Faker.Address.street_address()
+    price = Faker.Commerce.price()
+
+    {:ok, property} = generate_property()
+
+    {:ok, view, _html} = live(conn, "/properties/#{property.id}")
+
+    html =
+      view
+      |> element("#property-edit-form")
+      |> render_submit(%{name: name, address: address, price: price})
+
+    assert html =~ "Edit #{name}"
+    assert html =~ "#{name} was updated successfully"
+  end
+end

--- a/test/live/property/list_test.exs
+++ b/test/live/property/list_test.exs
@@ -1,0 +1,16 @@
+defmodule TenanteeWeb.PropertyListLiveTest do
+  use TenanteeWeb.ConnCase
+  import Phoenix.LiveViewTest
+  import Tenantee.Test.Factory.Property
+  @endpoint TenanteeWeb.Endpoint
+
+  test "renders list of properties", %{conn: conn} do
+    {:ok, property} = generate_property()
+    {:ok, _view, html} = live(conn, "/properties")
+
+    assert html =~ "Manage your properties"
+
+    assert html =~ property.name
+    assert html =~ property.address
+  end
+end

--- a/test/live/tenant/add_test.exs
+++ b/test/live/tenant/add_test.exs
@@ -1,0 +1,28 @@
+defmodule TenanteeWeb.TenantAddLiveTest do
+  use TenanteeWeb.ConnCase
+  import Phoenix.LiveViewTest
+  @endpoint TenanteeWeb.Endpoint
+
+  test "renders", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/tenants/new")
+
+    assert html =~ "Create new tenant"
+    assert html =~ "First name"
+    assert html =~ "Last name"
+  end
+
+  test "redirects to edit page after creation", %{conn: conn} do
+    first_name = Faker.Person.first_name()
+    last_name = Faker.Person.last_name()
+
+    {:ok, og_view, _html} = live(conn, "/tenants/new")
+
+    {:ok, _view, html} =
+      og_view
+      |> form("#tenant-add-form", %{first_name: first_name, last_name: last_name})
+      |> render_submit()
+      |> follow_redirect(conn)
+
+    assert html =~ "Edit #{first_name} #{last_name}"
+  end
+end

--- a/test/live/tenant/edit_test.exs
+++ b/test/live/tenant/edit_test.exs
@@ -1,0 +1,31 @@
+defmodule TenanteeWeb.TenantEditLiveTest do
+  use TenanteeWeb.ConnCase
+  import Phoenix.LiveViewTest
+  import Tenantee.Test.Factory.Tenant
+  @endpoint TenanteeWeb.Endpoint
+
+  test "renders", %{conn: conn} do
+    {:ok, tenant} = generate_tenant()
+    {:ok, _view, html} = live(conn, "/tenants/#{tenant.id}")
+
+    assert html =~ "Edit #{tenant.first_name} #{tenant.last_name}"
+    assert html =~ "First name"
+    assert html =~ "Last name"
+  end
+
+  test "updates successfully", %{conn: conn} do
+    first_name = Faker.Person.first_name()
+    last_name = Faker.Person.last_name()
+
+    {:ok, tenant} = generate_tenant()
+    {:ok, view, _html} = live(conn, "/tenants/#{tenant.id}")
+
+    html =
+      view
+      |> element("#tenant-edit-form")
+      |> render_submit(%{first_name: first_name, last_name: last_name})
+
+    assert html =~ "Edit #{first_name} #{last_name}"
+    assert html =~ "#{first_name} #{last_name} was updated successfully"
+  end
+end

--- a/test/support/factory/property.ex
+++ b/test/support/factory/property.ex
@@ -1,0 +1,29 @@
+defmodule Tenantee.Test.Factory.Property do
+  @moduledoc """
+  Property factory for Tenantee tests.
+  """
+  alias Tenantee.Schema.Property
+  alias Tenantee.Repo
+
+  @doc """
+  Generates and inserts a property with the given `attrs`
+  or the default attributes if none are given.
+  """
+  @spec generate_property(Keyword.t()) :: {:ok, term()} | {:error, term()}
+  def generate_property(attrs \\ []) do
+    name = Keyword.get(attrs, :name, Faker.Company.En.name())
+    description = Keyword.get(attrs, :description, Faker.Company.En.bs())
+    address = Keyword.get(attrs, :address, Faker.Address.En.street_address())
+    amount = Keyword.get(attrs, :amount, Faker.Commerce.price())
+    price = Money.from_float(amount, "USD")
+
+    %Property{}
+    |> Property.changeset(%{
+      name: name,
+      description: description,
+      address: address,
+      price: price
+    })
+    |> Repo.insert()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,7 @@
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Tenantee.Repo, :manual)
+# TODO: Redis is not sandboxed yet. Only override the config if
+# it doesn't exist.
+if is_nil(Tenantee.Config.get(:currency, nil)) do
+  Tenantee.Config.set(:currency, :USD)
+end


### PR DESCRIPTION
For performance reasons, this seems like a better idea than to just track every phx-change event.
On slow connections, phx-change won't be of much use whilst client-side JS certainly will.