### PR TITLE
Fix rent event and tenant create

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN mix local.hex --force
 RUN mix local.rebar --force
 RUN mix archive.install hex phx_new ${PHOENIX_VERSION}
 
+RUN mix deps.get
 RUN mix ecto.create && mix ecto.migrate
 RUN mix phx.gen.cert
 RUN mix assets.deploy

--- a/lib/tenantee/entity/tenant.ex
+++ b/lib/tenantee/entity/tenant.ex
@@ -133,7 +133,7 @@ defmodule Tenantee.Entity.Tenant do
       [
         :properties,
         :communication_channels,
-        rents: from(r in Rent, where: r.tenant_id == ^tenant.id, order_by: [desc: r.due_date])
+        rents: from(r in Rent, where: r.tenant_id == ^tenant.id, order_by: [desc: r.id])
       ]
     )
   end

--- a/lib/tenantee/entity/tenant.ex
+++ b/lib/tenantee/entity/tenant.ex
@@ -58,7 +58,7 @@ defmodule Tenantee.Entity.Tenant do
   @spec update(integer(), map()) :: :ok | {:error, Ecto.Changeset.t() | String.t()}
   def update(id, attrs) do
     with {:ok, tenant} <- get(id),
-         changeset <- Schema.changeset(tenant, attrs),
+         changeset <- Schema.edit_changeset(tenant, attrs),
          {:ok, _} <- Repo.update(changeset) do
       :ok
     end

--- a/lib/tenantee/schema/tenant.ex
+++ b/lib/tenantee/schema/tenant.ex
@@ -29,17 +29,22 @@ defmodule Tenantee.Schema.Tenant do
 
     has_many(:rents, Rent)
     many_to_many(:properties, Property, join_through: "leases", on_replace: :delete)
-    has_many(:communication_channels, CommunicationChannel)
+    has_many(:communication_channels, CommunicationChannel, on_replace: :delete)
 
     timestamps()
   end
 
   def changeset(tenant, attrs \\ %{}) do
     tenant
-    |> cast(attrs, [:first_name, :last_name])
-    |> validate_required([:first_name, :last_name])
+    |> edit_changeset(attrs)
     |> put_assoc(:properties, [])
     |> put_assoc(:communication_channels, [])
+  end
+
+  def edit_changeset(tenant, attrs \\ %{}) do
+    tenant
+    |> cast(attrs, [:first_name, :last_name])
+    |> validate_required([:first_name, :last_name])
   end
 
   def set_properties(%__MODULE__{} = tenant, properties) do

--- a/lib/tenantee_web/components/rent.ex
+++ b/lib/tenantee_web/components/rent.ex
@@ -46,7 +46,7 @@ defmodule TenanteeWeb.Components.Rent do
 
   defp pay_rent(id, rent_id) do
     JS.set_attribute({"disabled", true}, to: "##{id}")
-    |> JS.push("pay_rent", value: %{rent: rent_id})
+    |> JS.push("pay", value: %{rent: rent_id})
   end
 
   defp format_price(price) do


### PR DESCRIPTION
- Rent event in wrong on `phx-click`, and the order by is wrong.
- If you create a tenant and give him a communication channel, editing that tenant will result in a error.